### PR TITLE
0_Introduction: Use gif instead of animation

### DIFF
--- a/0_Introduction.ipynb
+++ b/0_Introduction.ipynb
@@ -152,7 +152,7 @@
     "using StatsPlots\n",
     "\n",
     "# Make an animation.\n",
-    "animation = @animate for (i, N) in enumerate(Ns)\n",
+    "animation = @gif for (i, N) in enumerate(Ns)\n",
     "\n",
     "    # Count the number of heads and tails.\n",
     "    heads = sum(data[1:i-1])\n",
@@ -649,7 +649,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.0.0",
+   "display_name": "Julia 1.0.3",
    "language": "julia",
    "name": "julia-1.0"
   },
@@ -657,7 +657,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.0.0"
+   "version": "1.0.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
If I use `@animation`, I get some 100 pngs instead of a single animation, whereas `@gif` gives a nice animation. However, I am using `Julia v1.0.3` instead of `Julia v1.0.0` in which the notebook was written.