### PR TITLE
[WIP] Remove Plots from tutorials that have StatsPlots

### DIFF
--- a/markdown/0_Introduction.md
+++ b/markdown/0_Introduction.md
@@ -24,7 +24,7 @@ First, let's load some of the packages we need to flip a coin (`Random`, `Distri
 using Random
 
 # Load a plotting library.
-using Plots
+using StatsPlots
 
 # Load the distributions library.
 using Distributions
@@ -91,9 +91,6 @@ The intuition about this definition is that the variance of the distribution wil
 
 
 ```julia
-# Import StatsPlots for animating purposes.
-using StatsPlots
-
 # Make an animation.
 animation = @gif for (i, N) in enumerate(Ns)
 

--- a/markdown/10_BayesianDiffEq.md
+++ b/markdown/10_BayesianDiffEq.md
@@ -9,8 +9,8 @@ Most of the scientific community deals with the basic problem of trying to mathe
 ```julia
 using Turing, Distributions, DataFrames, DifferentialEquations, DiffEqSensitivity
 
-# Import MCMCChain, Plots, and StatsPlots for visualizations and diagnostics.
-using MCMCChains, Plots, StatsPlots
+# Import MCMCChain, and StatsPlots for visualizations and diagnostics.
+using MCMCChains, StatsPlots
 
 # Set a seed for reproducibility.
 using Random

--- a/markdown/2_LogisticRegression.md
+++ b/markdown/2_LogisticRegression.md
@@ -16,8 +16,8 @@ using Turing, Distributions
 # Import RDatasets.
 using RDatasets
 
-# Import MCMCChains, Plots, and StatsPlots for visualizations and diagnostics.
-using MCMCChains, Plots, StatsPlots
+# Import MCMCChains, and StatsPlots for visualizations and diagnostics.
+using MCMCChains, StatsPlots
 
 # We need a logistic function, which is provided by StatsFuns.
 using StatsFuns: logistic

--- a/markdown/4_BayesHmm.md
+++ b/markdown/4_BayesHmm.md
@@ -9,7 +9,7 @@ Let's load the libraries we'll need. We also set a random seed (for reproducibil
 
 ```julia
 # Load libraries.
-using Turing, Plots, Random
+using Turing, StatsPlots, Random
 
 # Turn off progress monitor.
 Turing.turnprogress(false);
@@ -116,9 +116,6 @@ The code below generates an animation showing the graph of the data above, and t
 
 
 ```julia
-# Import StatsPlots for animating purposes.
-using StatsPlots
-
 # Extract our m and s parameters from the chain.
 m_set = c[:m].value.data
 s_set = c[:s].value.data

--- a/markdown/5_LinearRegression.md
+++ b/markdown/5_LinearRegression.md
@@ -17,8 +17,8 @@ using Turing, Distributions
 # Import RDatasets.
 using RDatasets
 
-# Import MCMCChains, Plots, and StatPlots for visualizations and diagnostics.
-using MCMCChains, Plots, StatsPlots
+# Import MCMCChains, and StatPlots for visualizations and diagnostics.
+using MCMCChains, StatsPlots
 
 # Functionality for splitting and normalizing the data.
 using MLDataUtils: shuffleobs, splitobs, rescale!

--- a/markdown/7_PoissonRegression.md
+++ b/markdown/7_PoissonRegression.md
@@ -15,8 +15,8 @@ We start by importing the required libraries.
 #Import Turing, Distributions and DataFrames
 using Turing, Distributions, DataFrames, Distributed
 
-# Import MCMCChain, Plots, and StatsPlots for visualizations and diagnostics.
-using MCMCChains, Plots, StatsPlots
+# Import MCMCChain, and StatsPlots for visualizations and diagnostics.
+using MCMCChains, StatsPlots
 
 # Set a seed for reproducibility.
 using Random

--- a/markdown/9_VariationalInference.md
+++ b/markdown/9_VariationalInference.md
@@ -266,7 +266,7 @@ samples = rand(q, 10000);
 
 ```julia
 # setup for plotting
-using Plots, LaTeXStrings, StatsPlots
+using LaTeXStrings, StatsPlots
 pyplot()
 ```
 
@@ -277,7 +277,7 @@ pyplot()
 
 
 
-    Plots.PyPlotBackend()
+    StatsPlots.PyPlotBackend()
 
 
 


### PR DESCRIPTION
[`StatsPlots` reexports `Plots`](https://github.com/JuliaPlots/StatsPlots.jl/blob/master/src/StatsPlots.jl#L8), so if you have `using StatsPlots`, then `using Plots` is redundant.

This is a relatively straightforward PR, where I've removed the `using Plots` from all of the tutorials where `using StatsPlots` is also used. There are a couple of instances where `using Plots` was used early in the tutorial, and `using StatsPlots` was used later. If you think those should stay as they were for clarity, I'm happy to revert.

I'm also a bit confused about the development process here. I edited the markdown directly, but it looks like maybe the expectation is that one would edit the notebooks, then run `render-exammple.bash`? But the README says that you have to run `weave-example.jl` if you change something, and `render-example.bash already seems to do this. Some more instruction on the steps to make this usable would be appreciated.