### PR TITLE
Fix order heads and tails in the Beta distribution

### DIFF
--- a/0_Introduction.ipynb
+++ b/0_Introduction.ipynb
@@ -170,7 +170,7 @@
     "    tails = N - heads\n",
     "    \n",
     "    # Update our prior belief in closed form (this is possible because we use a conjugate prior).\n",
-    "    updated_belief = Beta(prior_belief.α + heads, prior_belief.β + tails)\n",
+    "    updated_belief = Beta(prior_belief.α + tails, prior_belief.β + heads)\n",
     "\n",
     "    # Plotting\n",
     "    plot(updated_belief, \n",


### PR DESCRIPTION
The order was reversed as could be seen by computing the posterior distribution for one heads or one tails.
For example, if you calculated the posterior for a sample of size one and containing one heads, the posterior plot would show that the parameter is most likely to be `0` whereas the plot shows that an higher value means a higher probability for heads.

Note that I haven't run the notebook again to fix the GIF. This is because it would take me about 30 minutes to setup Jupyter again. This is a minor fix, which I guess will be end up into the tutorials at some point.