### PR TITLE
GIFs will now export properly using Weave

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,9 @@ version = "0.1.0"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Weave = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
 
 [compat]


### PR DESCRIPTION
This is a "fix" (more of a hack tbh) that makes it so that gifs will be exported as similarly to figures when exporting to markdown, and so it will all be rendered correctly by our setup for Turing.jl.