### PR TITLE
Update CompatHelper.yml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -16,16 +16,4 @@ jobs:
         run: |
           using Pkg
           Pkg.add("CompatHelper")
-
-      - name: Run CompatHelper
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
-        shell: julia --color=yes {0}
-        run: |
-          using CompatHelper
-          dir = "tutorials"
-          tutorials_dirs = readdir(dir)
-          subdirs = joinpath.(dir, tutorials_dirs)
-          subdirs = [""; subdirs]
           CompatHelper.main(; subdirs)


### PR DESCRIPTION
CompatHelper is opening too many PRs due to some internal rewrites on their side. Let's disable it for a few months and try to get the already open PRs done. We don't need extra PRs for now.

See also: https://github.com/JuliaRegistries/CompatHelper.jl/issues/378 or other issues at CompatHelper.