### PR TITLE
Remove `#! format:` comments

### DIFF
--- a/tutorials/09-variational-inference/09_variational-inference.jmd
+++ b/tutorials/09-variational-inference/09_variational-inference.jmd
@@ -76,9 +76,7 @@ samples_nuts = sample(m, NUTS(200, 0.65), 10_000);
 Now let's try VI. The most important function you need to now about to do VI in Turing is `vi`:
 
 ```julia
-#! format: off
 @doc(Variational.vi)
-#! format: on
 ```
 
 Additionally, you can pass
@@ -89,17 +87,13 @@ Additionally, you can pass
 By default, i.e. when calling `vi(m, advi)`, Turing use a *mean-field* approximation with a multivariate normal as the base-distribution. Mean-field refers to the fact that we assume all the latent variables to be *independent*. This the "standard" ADVI approach; see [Automatic Differentiation Variational Inference (2016)](https://arxiv.org/abs/1603.00788) for more. In Turing, one can obtain such a mean-field approximation by calling `Variational.meanfield(model)` for which there exists an internal implementation for `update`:
 
 ```julia
-#! format: off
 @doc(Variational.meanfield)
-#! format: on
 ```
 
 Currently the only implementation of `VariationalInference` available is `ADVI`, which is very convenient and applicable as long as your `Model` is differentiable with respect to the *variational parameters*, that is, the parameters of your variational distribution, e.g. mean and variance in the mean-field approximation.
 
 ```julia
-#! format: off
 @doc(Variational.ADVI)
-#! format: on
 ```
 
 To perform VI on the model `m` using 10 samples for gradient estimation and taking 1000 gradient steps is then as simple as:


### PR DESCRIPTION
With the latest version of CSTParser (used by JuliaFormatter) code with `@doc(...)` + trailing newline can be formatted correctly (see https://github.com/domluna/JuliaFormatter.jl/issues/555 and https://github.com/julia-vscode/CSTParser.jl/issues/328). Hence we can remove the JuliaFormatter instructions.