### PR TITLE
Update 10_bayesian-differential-equations.jmd

### DIFF
--- a/tutorials/10-bayesian-differential-equations/10_bayesian-differential-equations.jmd
+++ b/tutorials/10-bayesian-differential-equations/10_bayesian-differential-equations.jmd
@@ -47,7 +47,7 @@ With the `saveat` [argument](https://docs.sciml.ai/latest/basics/common_solver_o
 sol1 = solve(prob1, Tsit5(); saveat=0.1)
 odedata = Array(sol1) + 0.8 * randn(size(Array(sol1)))
 plot(sol1; alpha=0.3, legend=false);
-scatter!(sol1.t, odedata');
+scatter!(sol1.t, odedata')
 ```
 
 ## Direct Handling of Bayesian Estimation with Turing
@@ -98,7 +98,7 @@ pl = scatter(sol1.t, odedata');
 ```julia
 chain_array = Array(chain)
 for k in 1:300
-    resol = solve(remake(prob1; p=chain_array[rand(1:1500), 1:4]), Tsit5(); saveat=0.1)
+    resol = solve(remake(prob1; p=chain_array[rand(1:1500), 2:5]), Tsit5(); saveat=0.1)
     plot!(resol; alpha=0.1, color="#BBBBBB", legend=false)
 end
 # display(pl)
@@ -146,7 +146,7 @@ chain2 = sample(model2, NUTS(0.45), MCMCThreads(), 5000, 3; progress=false)
 pl = scatter(sol1.t, odedata');
 chain_array2 = Array(chain2)
 for k in 1:300
-    resol = solve(remake(prob1; p=chain_array2[rand(1:12000), 1:4]), Tsit5(); saveat=0.1)
+    resol = solve(remake(prob1; p=chain_array2[rand(1:12000), 2:5]), Tsit5(); saveat=0.1)
     # Note that due to a bug in AxisArray, the variables from the chain will be returned always in
     # the order it is stored in the array, not by the specified order in the call - :α, :β, :γ, :δ
     plot!(resol; alpha=0.1, color="#BBBBBB", legend=false)
@@ -239,7 +239,7 @@ Finally, we select a 100 sets of parameters from the first chain and plot soluti
 pl = scatter(sol.t, ddedata')
 chain_array = Array(chain)
 for k in 1:100
-    resol = solve(remake(prob1; p=chain_array[rand(1:450), 1:4]), Tsit5(); saveat=0.1)
+    resol = solve(remake(prob1; p=chain_array[rand(1:450), 2:5]), Tsit5(); saveat=0.1)
     # Note that due to a bug in AxisArray, the variables from the chain will be returned always in
     # the order it is stored in the array, not by the specified order in the call - :α, :β, :γ, :δ
 


### PR DESCRIPTION
Add scatter plot that was swallowed by ';'. Further, use the right parameters for retrodiction (the chain_array has sigma as its first column that should not be used by the ODE solver).

Solves #292. 