### PR TITLE
Abort build process when error occurs

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,3 +36,37 @@ TuringTutorials.weave(
     out_path_root=pkgdir,
     build=(:script, :html, :github, :notebook),
 )
+
+write(
+    joinpath(tutorials_dir, "test_error.jmd"),
+    """
+    ---
+    title: Test
+    author: TuringLang team
+    weave_options:
+      error : false
+    ---
+
+    This is a test of the builder system.
+
+    The code throws an error.
+    ```julia
+    error("some error occurred")
+    ```
+
+    ```julia, echo=false, skip="notebook"
+    using TuringTutorials
+    TuringTutorials.tutorial_footer(WEAVE_ARGS[:folder], WEAVE_ARGS[:file])
+    ```
+    """,
+)
+
+# Generate default output
+for build in (:html, :github)
+    @test_throws ErrorException("some error occurred") TuringTutorials.weave(
+        tutorials_dir,
+        "test_error.jmd";
+        out_path_root=pkgdir,
+	build=(build,),
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,9 +64,6 @@ write(
 # Generate default output
 for build in (:html, :github)
     @test_throws ErrorException("some error occurred") TuringTutorials.weave(
-        tutorials_dir,
-        "test_error.jmd";
-        out_path_root=pkgdir,
-	build=(build,),
+        tutorials_dir, "test_error.jmd"; out_path_root=pkgdir, build=(build,)
     )
 end

--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -2,6 +2,8 @@
 title: Introduction to Turing
 permalink: /:collection/:name/
 redirect_from: tutorials/0-introduction/
+weave_options:
+  error : false
 ---
 
 ## Introduction
@@ -199,7 +201,7 @@ histogram(chain)
 
 Now we can build our plot:
 
-```julia; echo=false; error=false
+```julia; echo=false
 @assert isapprox(mean(chain, :p), 0.5; atol=0.1)
 ```
 

--- a/tutorials/01-gaussian-mixture-model/01_gaussian-mixture-model.jmd
+++ b/tutorials/01-gaussian-mixture-model/01_gaussian-mixture-model.jmd
@@ -2,6 +2,8 @@
 title: Unsupervised Learning using Bayesian Mixture Models
 permalink: /:collection/:name/
 redirect_from: tutorials/1-gaussianmixturemodel/
+weave_options:
+  error : false
 ---
 
 The following tutorial illustrates the use of Turing for clustering data using a Bayesian mixture model.
@@ -114,7 +116,7 @@ nchains = 3
 chains = sample(model, sampler, MCMCThreads(), nsamples, nchains);
 ```
 
-```julia; echo=false; error=false
+```julia; echo=false
 let
     # Verify that the output of the chain is as expected.
     for i in MCMCChains.chains(chains)

--- a/tutorials/02-logistic-regression/02_logistic-regression.jmd
+++ b/tutorials/02-logistic-regression/02_logistic-regression.jmd
@@ -2,6 +2,8 @@
 title: Bayesian Logistic Regression
 permalink: /:collection/:name/
 redirect_from: tutorials/2-logisticregression/
+weave_options:
+  error : false
 ---
 
 [Bayesian logistic regression](https://en.wikipedia.org/wiki/Logistic_regression#Bayesian) is the Bayesian counterpart to a common tool in machine learning, logistic regression. The goal of logistic regression is to predict a one or a zero for a given training item. An example might be predicting whether someone is sick or ill given their symptoms and personal information.
@@ -133,7 +135,7 @@ chain = sample(m, HMC(0.05, 10), MCMCThreads(), 1_500, 3)
 describe(chain)
 ```
 
-```julia; echo=false; error=false
+```julia; echo=false
 let
     matrix = get(chain, :student).student
     values = Iterators.flatten(matrix)

--- a/tutorials/03-bayesian-neural-network/03_bayesian-neural-network.jmd
+++ b/tutorials/03-bayesian-neural-network/03_bayesian-neural-network.jmd
@@ -2,6 +2,8 @@
 title: Bayesian Neural Networks
 permalink: /:collection/:name/
 redirect_from: tutorials/3-bayesnn/
+weave_options:
+  error : false
 ---
 
 In this tutorial, we demonstrate how one can implement a Bayesian Neural Network using a combination of Turing and [Flux](https://github.com/FluxML/Flux.jl), a suite of machine learning tools. We will use Flux to specify the neural network's layers and Turing to implement the probabilistic inference, with the goal of implementing a classification algorithm.

--- a/tutorials/04-hidden-markov-model/04_hidden-markov-model.jmd
+++ b/tutorials/04-hidden-markov-model/04_hidden-markov-model.jmd
@@ -2,6 +2,8 @@
 title: Bayesian Hidden Markov Models
 permalink: /:collection/:name/
 redirect_from: tutorials/4-bayeshmm/
+weave_options:
+  error : false
 ---
 
 This tutorial illustrates training Bayesian [Hidden Markov Models](https://en.wikipedia.org/wiki/Hidden_Markov_model) (HMM) using Turing. The main goals are learning the transition matrix, emission parameter, and hidden states. For a more rigorous academic overview on Hidden Markov Models, see [An introduction to Hidden Markov Models and Bayesian Networks](http://mlg.eng.cam.ac.uk/zoubin/papers/ijprai.pdf) (Ghahramani, 2001).

--- a/tutorials/05-linear-regression/05_linear-regression.jmd
+++ b/tutorials/05-linear-regression/05_linear-regression.jmd
@@ -2,6 +2,8 @@
 title: Linear Regression
 permalink: /:collection/:name/
 redirect_from: tutorials/5-linearregression/
+weave_options:
+  error : false
 ---
 
 Turing is powerful when applied to complex hierarchical models, but it can also be put to task at common statistical procedures, like [linear regression](https://en.wikipedia.org/wiki/Linear_regression). This tutorial covers how to implement a linear regression model in Turing.
@@ -204,7 +206,7 @@ println(
 )
 ```
 
-```julia; echo=false; error=false
+```julia; echo=false
 let
     bayes_train_loss = msd(train_prediction_bayes, trainset[!, target])
     bayes_test_loss = msd(test_prediction_bayes, testset[!, target])

--- a/tutorials/06-infinite-mixture-model/06_infinite-mixture-model.jmd
+++ b/tutorials/06-infinite-mixture-model/06_infinite-mixture-model.jmd
@@ -2,6 +2,8 @@
 title: Probabilistic Modelling using the Infinite Mixture Model
 permalink: /:collection/:name/
 redirect_from: tutorials/6-infinitemixturemodel/
+weave_options:
+  error : false
 ---
 
 In many applications it is desirable to allow the model to adjust its complexity to the amount the data. Consider for example the task of assigning objects into clusters or groups. This task often involves the specification of the number of groups. However, often times it is not known beforehand how many groups exist. Moreover, in some applictions, e.g. modelling topics in text documents or grouping species, the number of examples per group is heavy tailed. This makes it impossible to predefine the number of groups and requiring the model to form new groups when data points from previously unseen groups are observed.

--- a/tutorials/07-poisson-regression/07_poisson-regression.jmd
+++ b/tutorials/07-poisson-regression/07_poisson-regression.jmd
@@ -2,6 +2,8 @@
 title: Bayesian Poisson Regression
 permalink: /:collection/:name/
 redirect_from: tutorials/7-poissonregression/
+weave_options:
+  error : false
 ---
 
 This notebook is ported from the [example notebook](https://docs.pymc.io/notebooks/GLM-poisson-regression.html) of PyMC3 on Poisson Regression.

--- a/tutorials/08-multinomial-logistic-regression/08_multinomial-logistic-regression.jmd
+++ b/tutorials/08-multinomial-logistic-regression/08_multinomial-logistic-regression.jmd
@@ -2,6 +2,8 @@
 title: Bayesian Multinomial Logistic Regression
 permalink: /:collection/:name/
 redirect_from: tutorials/8-multinomiallogisticregression/
+weave_options:
+  error : false
 ---
 
 [Multinomial logistic regression](https://en.wikipedia.org/wiki/Multinomial_logistic_regression) is an extension of logistic regression. Logistic regression is used to model problems in which there are exactly two possible discrete outcomes. Multinomial logistic regression is used to model problems in which there are two or more possible discrete outcomes.

--- a/tutorials/09-variational-inference/09_variational-inference.jmd
+++ b/tutorials/09-variational-inference/09_variational-inference.jmd
@@ -2,6 +2,8 @@
 title: Variational inference (VI) in Turing.jl
 permalink: /:collection/:name/
 redirect_from: tutorials/9-variationalinference/
+weave_options:
+  error : false
 ---
 
 In this post we'll have a look at what's know as **variational inference (VI)**, a family of _approximate_ Bayesian inference methods, and how to use it in Turing.jl as an alternative to other approaches such as MCMC. In particular, we will focus on one of the more standard VI methods called **Automatic Differentation Variational Inference (ADVI)**.
@@ -136,7 +138,7 @@ var(x), mean(x)
 (mean(rand(q, 1000); dims=2)...,)
 ```
 
-```julia; echo=false; error=false
+```julia; echo=false
 let
     v, m = (mean(rand(q, 1000); dims=2)...,)
     # On Turing version 0.14, this atol could be 0.01.
@@ -776,7 +778,7 @@ Test set:
     OLS loss: $ols_loss2")
 ```
 
-```julia; echo=false; error=false
+```julia; echo=false
 # Verify the loss on the test set.
 @assert vi_loss2 < 0.01
 @assert bayes_loss2 < 0.000001

--- a/tutorials/10-bayesian-differential-equations/10_bayesian-differential-equations.jmd
+++ b/tutorials/10-bayesian-differential-equations/10_bayesian-differential-equations.jmd
@@ -2,6 +2,8 @@
 title: Bayesian Estimation of Differential Equations
 permalink: /:collection/:name/
 redirect_from: tutorials/10-bayesiandiffeq/
+weave_options:
+  error : false
 ---
 
 Most of the scientific community deals with the basic problem of trying to mathematically model the reality around them and this often involves dynamical systems. The general trend to model these complex dynamical systems is through the use of differential equations. Differential equation models often have non-measurable parameters. The popular “forward-problem” of simulation consists of solving the differential equations for a given set of parameters, the “inverse problem” to simulation, known as parameter estimation, is the process of utilizing data to determine these model parameters.

--- a/tutorials/11-probabilistic-pca/11_probabilistic-pca.jmd
+++ b/tutorials/11-probabilistic-pca/11_probabilistic-pca.jmd
@@ -1,6 +1,8 @@
 ---
 title: Probabilistic Principal Component Analysis
 permalink: /:collection/:name/
+weave_options:
+  error : false
 ---
 
 Principal component analysis is a fundamental technique to analyse and visualise data.
@@ -158,7 +160,7 @@ This is what we expect, as PCA is essentially a lossless transformation, i.e. th
 
 And finally, we plot the data in a lower dimensional space. The interesting insight here is that we can project the information from the input space into a two-dimensional representation, without lossing the essential information about the two groups of cells in the input data.
 
-```julia; echo=false; error=false
+```julia; echo=false
 let
     diff = X' - expression_matrix
     @assert mean(diff[:, 4]) < 0.5
@@ -585,7 +587,7 @@ projections. We can see quite clearly that it is possible to separate Setosa fro
 Virginica species, but that the latter two cannot be clearly separated based on the pPCA projection. This can be
 shown even more clearly by using a kernel density estimate and plotting the contours of that estimate.
 
-```julia; echo=false; error=false
+```julia; echo=false
 let
     m1 = mean(samples_raw[1, 1:50, :])
     m2 = mean(samples_raw[1, 51:100, :])

--- a/tutorials/12-gaussian-process/12_gaussian-process.jmd
+++ b/tutorials/12-gaussian-process/12_gaussian-process.jmd
@@ -2,6 +2,8 @@
 title: Gaussian Process Latent Variable Model
 permalink: /:collection/:name/
 redirect_from: tutorials/12-gaussian-process/
+weave_options:
+  error : false
 ---
 
 # Gaussian Process Latent Variable Model
@@ -212,7 +214,7 @@ p_gplvm = @vlplot(:point, x = :ard1, y = :ard2, color = "labels:n")(df_gplvm)
 p_gplvm
 ```
 
-```julia; echo=false; error=false
+```julia; echo=false
 let
     @assert abs(
         mean(z_mean[alpha_indices[1], labels[1:n_data] .== "setosa"]) -


### PR DESCRIPTION
This should make it less likely to miss if a tutorial is broken. Without any options specified, Weave will just continue and include the error in the output. With this PR, Weave will throw an error instead and abort the build process.

Currently, the option is only specified for the hidden chunks with assertions but I think it's useful to set it for all chunks.