### PR TITLE
Use `filldist` in coinflip example

### DIFF
--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -155,21 +155,23 @@ using MCMCChains
 First, we define the coin-flip model using Turing.
 
 ```julia
-@model function coinflip(y)
+# Unconditioned coinflip model with `N` observations.
+@model function coinflip(; N::Int)
     # Our prior belief about the probability of heads in a coin toss.
     p ~ Beta(1, 1)
 
-    # The number of observations.
-    N = length(y)
-    for n in 1:N
-        # Heads or tails of a coin are drawn from a Bernoulli distribution.
-        y[n] ~ Bernoulli(p)
-    end
+    # Heads or tails of a coin are drawn from `N` independent and identically
+    # distributed Bernoulli distributions with success rate `p`.
+    y ~ filldist(Bernoulli(p), N)
 end;
+
+# Convenience method for constructing a coinflip model
+# that is conditioned on observations `y`.
+coinflip(y::AbstractVector{<:Real}) = coinflip(; N=length(y)) | (; y)
 ```
 
-In the Turing model the prior distribution of the variable `p`, the probability of heads in a coin toss, and the distribution of the observations `y[n]` are specified on the right-hand side of the `~` expressions.
-The `@model` macro modifies the body of the Julia function `coinflip(y)` and, e.g., replaces the `~` statements with internal function calls that are used for sampling.
+In the Turing model the prior distribution of the variable `p`, the probability of heads in a coin toss, and the distribution of the observations `y` are specified on the right-hand side of the `~` expressions.
+The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling.
 
 We combine the model with the observations:
 

--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -163,11 +163,13 @@ First, we define the coin-flip model using Turing.
     # Heads or tails of a coin are drawn from `N` independent and identically
     # distributed Bernoulli distributions with success rate `p`.
     y ~ filldist(Bernoulli(p), N)
-end;
+
+    return y
+end
 
 # Convenience method for constructing a coinflip model
 # that is conditioned on observations `y`.
-coinflip(y::AbstractVector{<:Real}) = coinflip(; N=length(y)) | (; y)
+coinflip(y::AbstractVector{<:Real}) = coinflip(; N=length(y)) | (; y);
 ```
 
 In the Turing model the prior distribution of the variable `p`, the probability of heads in a coin toss, and the distribution of the observations `y` are specified on the right-hand side of the `~` expressions.


### PR DESCRIPTION
When updating some other tutorials, I noticed that maybe we should use (and hence somewhat promote) `filldist` already in the coinflip example.

I think it should be more well-known and used (even though I would still like to unify and extend it in Distributions), since it
- makes it easier to sample from the prior (without having to use `missing` and/or type parameters),
- should be efficient regardless of the AD backend (since it does not enforce the use of `for` loops but allows AD backends to use an optimized implementation)