### PR TITLE
Adding link to condition/decondition docs in DynamicPPL

### DIFF
--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -173,7 +173,7 @@ coinflip(y::AbstractVector{<:Real}) = coinflip(; N=length(y)) | (; y);
 ```
 
 In the Turing model the prior distribution of the variable `p`, the probability of heads in a coin toss, and the distribution of the observations `y` are specified on the right-hand side of the `~` expressions.
-The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling. 
+The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling.
 
 We have also defined a convenience function that makes use of the `condition` syntax (see ['Condition & decondition'](https://beta.turing.ml/DynamicPPL.jl/stable/api/#Condition-and-decondition) in DynamicPPL.jl
 for details). We then combine the model with the observations:

--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -171,7 +171,7 @@ end;
 In the Turing model the prior distribution of the variable `p`, the probability of heads in a coin toss, and the distribution of the observations `y` are specified on the right-hand side of the `~` expressions.
 The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling.
 
-Here we defined a model that is not conditioned on any specific observations as this allows us to easily obtain samples of `y` from the prior with
+Here we defined a model that is not conditioned on any specific observations as this allows us to easily obtain samples of both `p` and `y` with
 
 ```julia
 rand(coinflip(; N))

--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -172,6 +172,7 @@ In the Turing model the prior distribution of the variable `p`, the probability 
 The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling.
 
 Here we defined a model that is not conditioned on any specific observations as this allows us to easily obtain samples of `y` from the prior with
+
 ```julia
 rand(coinflip(; N))
 ```

--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -165,20 +165,24 @@ First, we define the coin-flip model using Turing.
     y ~ filldist(Bernoulli(p), N)
 
     return y
-end
-
-# Convenience method for constructing a coinflip model
-# that is conditioned on observations `y`.
-coinflip(y::AbstractVector{<:Real}) = coinflip(; N=length(y)) | (; y);
+end;
 ```
 
 In the Turing model the prior distribution of the variable `p`, the probability of heads in a coin toss, and the distribution of the observations `y` are specified on the right-hand side of the `~` expressions.
 The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling.
 
-We have also defined a convenience function that makes use of the `condition` syntax (see ['Condition & decondition'](https://beta.turing.ml/DynamicPPL.jl/stable/api/#Condition-and-decondition) in DynamicPPL.jl
-for details). We then combine the model with the observations:
+Here we defined a model that is not conditioned on any specific observations as this allows us to easily obtain samples of `y` from the prior with
+```julia
+rand(coinflip(; N))
+```
+
+The model can be conditioned on some observations with `|`.
+See the [documentation of the `condition` syntax](https://beta.turing.ml/DynamicPPL.jl/stable/api/#Condition-and-decondition) in DynamicPPL.jl for more details.
+In the conditioned `model` the observations `y` are fixed to `data`.
 
 ```julia
+coinflip(y::AbstractVector{<:Real}) = coinflip(; N=length(y)) | (; y)
+
 model = coinflip(data);
 ```
 

--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -173,9 +173,10 @@ coinflip(y::AbstractVector{<:Real}) = coinflip(; N=length(y)) | (; y);
 ```
 
 In the Turing model the prior distribution of the variable `p`, the probability of heads in a coin toss, and the distribution of the observations `y` are specified on the right-hand side of the `~` expressions.
-The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling.
+The `@model` macro modifies the body of the Julia function `coinflip` and, e.g., replaces the `~` statements with internal function calls that are used for sampling. 
 
-We combine the model with the observations:
+We have also defined a convenience function that makes use of the `condition` syntax (see ['Condition & decondition'](https://beta.turing.ml/DynamicPPL.jl/stable/api/#Condition-and-decondition) in DynamicPPL.jl
+for details). We then combine the model with the observations:
 
 ```julia
 model = coinflip(data);


### PR DESCRIPTION
Following up on a user comment in slack, I've added a link to the docs on condition/decondition syntax in the coin-flip example. 