### PR TITLE
Fix manifest action

### DIFF
--- a/.github/workflows/UpdateManifests.yml
+++ b/.github/workflows/UpdateManifests.yml
@@ -21,27 +21,6 @@ jobs:
       - name: "Update Manifest.toml files"
         run: find tutorials/ -type f -name Manifest.toml -exec julia --color=yes -e "using Pkg; Pkg.activate(dirname(ARGS[1])); Pkg.instantiate(); Pkg.update()'" {} \;
       - run: git status
-      - name: "Upload Manifest.toml files"
-        uses: actions/upload-artifact@v2
-        with:
-          name: manifest_files
-          path: tutorials/**/Manifest.toml
-          if-no-files-found: error
-  pr:
-    needs: update
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: "Download Manifest.toml files"
-        uses: actions/download-artifact@v3
-        with:
-          name: manifest_files
-          path: /tmp/manifest_files
-      - name: "Update existing Manifest.toml files"
-        run: rsync -avc /tmp/manifest_files/tutorials .
-      - name: "Remove download"
-        run: rm -rf /tmp/manifest_files
-      - run: git status
       - uses: peter-evans/create-pull-request@v4
         with:
           delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@
 *.log
 *.out
 *.tex
-tutorials/**/*.html
-tutorials/**/*.pdf
+/tutorials/**/*.html
+/tutorials/**/*.pdf
+/tutorials/**/Project.toml
 Testing/
 /*/*/jl_*/
 /Manifest.toml


### PR DESCRIPTION
This should fix the error in https://github.com/TuringLang/TuringTutorials/actions/runs/3735405814/jobs/6339423325 (the `update` job worked fine, the problem was the extraction of the manifest files). The artifact setup was copied from https://github.com/julia-actions/manifest-updater-examples but I think it's not needed here.