### PR TITLE
Use `NUTS` sampler instead of `HMC`

### DIFF
--- a/tutorials/00-introduction/00_introduction.jmd
+++ b/tutorials/00-introduction/00_introduction.jmd
@@ -193,7 +193,7 @@ In this example, we use a [Hamiltonian Monte Carlo](https://en.wikipedia.org/wik
 Other tutorials give more information on the samplers available in Turing and discuss their use for different models.
 
 ```julia
-sampler = HMC(0.05, 10);
+sampler = NUTS();
 ```
 
 We approximate the posterior distribution with 1000 samples:

--- a/tutorials/01-gaussian-mixture-model/01_gaussian-mixture-model.jmd
+++ b/tutorials/01-gaussian-mixture-model/01_gaussian-mixture-model.jmd
@@ -110,7 +110,7 @@ We use a `Gibbs` sampler that combines a [particle Gibbs](https://www.stats.ox.a
 We generate multiple chains in parallel using multi-threading.
 
 ```julia
-sampler = Gibbs(PG(100, :k), HMC(0.05, 10, :μ, :w))
+sampler = Gibbs(PG(100, :k), NUTS(-1, 0.65, :μ, :w))
 nsamples = 100
 nchains = 3
 chains = sample(model, sampler, MCMCThreads(), nsamples, nchains);

--- a/tutorials/02-logistic-regression/02_logistic-regression.jmd
+++ b/tutorials/02-logistic-regression/02_logistic-regression.jmd
@@ -127,7 +127,7 @@ n, _ = size(train)
 
 # Sample using HMC.
 m = logistic_regression(train, train_label, n, 1)
-chain = sample(m, HMC(0.05, 10), MCMCThreads(), 1_500, 3)
+chain = sample(m, NUTS(), MCMCThreads(), 1_500, 3)
 ```
 
 ```julia; echo=false

--- a/tutorials/03-bayesian-neural-network/03_bayesian-neural-network.jmd
+++ b/tutorials/03-bayesian-neural-network/03_bayesian-neural-network.jmd
@@ -106,13 +106,13 @@ The probabilistic model specification below creates a `parameters` variable, whi
 end;
 ```
 
-Inference can now be performed by calling `sample`. We use the `HMC` sampler here.
+Inference can now be performed by calling `sample`. We use the `NUTS` Hamiltonian Monte Carlo sampler here.
 
 ```julia
 # Perform inference.
 N = 5000
 ch = sample(
-    bayes_nn(hcat(xs...), ts, length(parameters_initial), reconstruct), HMC(0.05, 4), N
+    bayes_nn(hcat(xs...), ts, length(parameters_initial), reconstruct), NUTS(), N
 );
 ```
 

--- a/tutorials/04-hidden-markov-model/04_hidden-markov-model.jmd
+++ b/tutorials/04-hidden-markov-model/04_hidden-markov-model.jmd
@@ -126,7 +126,7 @@ The parameter `s` is not a continuous variable. It is a vector of **integers**, 
 Time to run our sampler.
 
 ```julia
-g = Gibbs(HMC(0.01, 50, :m, :T), PG(120, :s))
+g = Gibbs(NUTS(-1, 0.65, :m, :T), PG(120, :s))
 chn = sample(BayesHmm(y, 3), g, 1000);
 ```
 

--- a/tutorials/05-linear-regression/05_linear-regression.jmd
+++ b/tutorials/05-linear-regression/05_linear-regression.jmd
@@ -131,7 +131,7 @@ With our model specified, we can call the sampler. We will use the No U-Turn Sam
 
 ```julia
 model = linear_regression(train, train_target)
-chain = sample(model, NUTS(0.65), 3_000)
+chain = sample(model, NUTS(), 3_000)
 ```
 
 We can also check the densities and traces of the parameters visually using the `plot` functionality.

--- a/tutorials/07-poisson-regression/07_poisson-regression.jmd
+++ b/tutorials/07-poisson-regression/07_poisson-regression.jmd
@@ -152,7 +152,7 @@ n, _ = size(data)
 
 num_chains = 4
 m = poisson_regression(data, data_labels, n, 10)
-chain = sample(m, NUTS(200, 0.65), MCMCThreads(), 2_500, num_chains; discard_adapt=false)
+chain = sample(m, NUTS(), MCMCThreads(), 2_500, num_chains; discard_adapt=false)
 ```
 
 # Viewing the Diagnostics

--- a/tutorials/08-multinomial-logistic-regression/08_multinomial-logistic-regression.jmd
+++ b/tutorials/08-multinomial-logistic-regression/08_multinomial-logistic-regression.jmd
@@ -123,7 +123,7 @@ Now we can run our sampler. This time we'll use [`HMC`](http://turing.ml/docs/li
 
 ```julia
 m = logistic_regression(train_features, train_target, 1)
-chain = sample(m, HMC(0.05, 10), MCMCThreads(), 1_500, 3)
+chain = sample(m, NUTS(), MCMCThreads(), 1_500, 3)
 ```
 
 Since we ran multiple chains, we may as well do a spot check to make sure each chain converges around similar points.

--- a/tutorials/09-variational-inference/09_variational-inference.jmd
+++ b/tutorials/09-variational-inference/09_variational-inference.jmd
@@ -73,7 +73,7 @@ We'll produce 10 000 samples with 200 steps used for adaptation and a target acc
 If you don't understand what "adaptation" or "target acceptance rate" refers to, all you really need to know is that `NUTS` is known to be one of the most accurate and efficient samplers (when applicable) while requiring little to no hand-tuning to work well.
 
 ```julia
-samples_nuts = sample(m, NUTS(200, 0.65), 10_000);
+samples_nuts = sample(m, NUTS(), 10_000);
 ```
 
 Now let's try VI. The most important function you need to now about to do VI in Turing is `vi`:
@@ -467,7 +467,7 @@ plot_variational_marginals(z, sym2range)
 And let's compare this to using the `NUTS` sampler:
 
 ```julia
-chain = sample(m, NUTS(0.65), 10_000);
+chain = sample(m, NUTS(), 10_000);
 ```
 
 ```julia

--- a/tutorials/10-bayesian-differential-equations/10_bayesian-differential-equations.jmd
+++ b/tutorials/10-bayesian-differential-equations/10_bayesian-differential-equations.jmd
@@ -111,7 +111,7 @@ end
 model = fitlv(odedata, prob)
 
 # Sample 3 independent chains with forward-mode automatic differentiation (the default).
-chain = sample(model, NUTS(0.65), MCMCSerial(), 1000, 3; progress=false)
+chain = sample(model, NUTS(), MCMCSerial(), 1000, 3; progress=false)
 ```
 
 The estimated parameters are close to the parameter values the observations were generated with.
@@ -271,7 +271,7 @@ end
 model_dde = fitlv_dde(ddedata, prob_dde)
 
 # Sample 3 independent chains.
-chain_dde = sample(model_dde, NUTS(0.65), MCMCSerial(), 300, 3; progress=false)
+chain_dde = sample(model_dde, NUTS(), MCMCSerial(), 300, 3; progress=false)
 ```
 
 ```julia
@@ -324,7 +324,7 @@ using Zygote, SciMLSensitivity
 
 # Sample a single chain with 1000 samples using Zygote.
 setadbackend(:zygote)
-sample(model, NUTS(0.65), 1000; progress=false)
+sample(model, NUTS(), 1000; progress=false)
 ```
 
 If desired, we can control the sensitivity analysis method that is used by providing the `sensealg` keyword argument to `solve`.
@@ -355,7 +355,7 @@ model_sensealg = fitlv_sensealg(odedata, prob)
 
 # Sample a single chain with 1000 samples using Zygote.
 setadbackend(:zygote)
-sample(model_sensealg, NUTS(0.65), 1000; progress=false)
+sample(model_sensealg, NUTS(), 1000; progress=false)
 ```
 
 For more examples of adjoint usage on large parameter models, consult the [DiffEqFlux documentation](https://diffeqflux.sciml.ai/dev/).

--- a/tutorials/docs-00-getting-started/00_getting-started.jmd
+++ b/tutorials/docs-00-getting-started/00_getting-started.jmd
@@ -52,7 +52,7 @@ end
 Then we can run a sampler to collect results. In this case, it is a Hamiltonian Monte Carlo sampler
 
 ```julia
-chn = sample(gdemo(1.5, 2), HMC(0.1, 5), 1000)
+chn = sample(gdemo(1.5, 2), NUTS(), 1000)
 ```
 
 We can plot the results


### PR DESCRIPTION
Replaces the non-adaptive `HMC` sampler with `NUTS` in the tutorials, based on a comment by @sethaxen on Slack.