### PR TITLE
Remove bounds on FillArrays

### DIFF
--- a/tutorials/01-gaussian-mixture-model/Project.toml
+++ b/tutorials/01-gaussian-mixture-model/Project.toml
@@ -5,6 +5,3 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[compat]
-FillArrays = "= 1.0.0"

--- a/tutorials/03-bayesian-neural-network/Project.toml
+++ b/tutorials/03-bayesian-neural-network/Project.toml
@@ -8,6 +8,3 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[compat]
-FillArrays = "= 1.0.0"

--- a/tutorials/05-linear-regression/Project.toml
+++ b/tutorials/05-linear-regression/Project.toml
@@ -8,6 +8,3 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[compat]
-FillArrays = "= 1.0.0"

--- a/tutorials/08-multinomial-logistic-regression/Project.toml
+++ b/tutorials/08-multinomial-logistic-regression/Project.toml
@@ -7,6 +7,3 @@ RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[compat]
-FillArrays = "= 1.0.0"

--- a/tutorials/09-variational-inference/Project.toml
+++ b/tutorials/09-variational-inference/Project.toml
@@ -11,6 +11,3 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
-
-[compat]
-FillArrays = "= 1.0.0"

--- a/tutorials/11-probabilistic-pca/Project.toml
+++ b/tutorials/11-probabilistic-pca/Project.toml
@@ -7,6 +7,3 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[compat]
-FillArrays = "= 1.0.0"

--- a/tutorials/12-gaussian-process/Project.toml
+++ b/tutorials/12-gaussian-process/Project.toml
@@ -9,6 +9,3 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[compat]
-FillArrays = "= 1.0.0"

--- a/tutorials/13-seasonal-time-series/Project.toml
+++ b/tutorials/13-seasonal-time-series/Project.toml
@@ -3,6 +3,3 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[compat]
-FillArrays = "= 1.0.0"


### PR DESCRIPTION
Not needed anymore since FillArrays 1.4.1 fixes the ReverseDiff + Tracker issues and the latest Turing release is compatible with this release.