### PR TITLE
Update prob query section of the doc following the removal of `prob` macro

### DIFF
--- a/tutorials/docs-12-using-turing-guide/using-turing-guide.jmd
+++ b/tutorials/docs-12-using-turing-guide/using-turing-guide.jmd
@@ -386,7 +386,7 @@ logpdf(Normal(0, sqrt(1.0)), 1.0)
 Querying with `Chains` object is easy as well:
 
 ```julia
-chn = sample(model, NUTS(), 10)
+chn = sample(model, Prior(), 10)
 ```
 
 ```julia


### PR DESCRIPTION
Ref https://github.com/TuringLang/DynamicPPL.jl/pull/604

I couldn't find a way to replicate the behavior of `prob` macro. Particularly, given
```julia
@model function gdemo0()
    s ~ InverseGamma(2, 3)
    m ~ Normal(0, sqrt(s))
    return x ~ Normal(m, sqrt(s))
end

model1 = gdemo0(1.0)
```
For
```julia
model2 = model1 | (x = 2.0,)
```
`loglikelihood(model2, (...))` will still use `x=1.0` to compute the loglikelihood. 

So I did some simplification, let me know the thoughts.